### PR TITLE
[TUBEMQ-166]Hide `bdbStore` configs in master.ini (docs)

### DIFF
--- a/docs/en-us/configure_introduction.md
+++ b/docs/en-us/configure_introduction.md
@@ -41,6 +41,7 @@ In addition to the back-end system configuration file, the Master also stores th
 | startConsumeAuthenticate      | no       | boolean | Whether to enable consumer user authentication, the default is false |
 | startConsumeAuthorize         | no       | boolean | Whether to enable consumer consumption authorization authentication, the default is false |
 | maxGroupBrokerConsumeRate     | no       | int     | The maximum ratio of the number of clustered brokers to the number of members in the consumer group. The default is 50. In a 50-kerrow cluster, one consumer group is allowed to start at least one client. |
+| metaDataPath                  | no       | string  | Metadata storage path. Absolute, or relative to TubeMQ base directory (`$BASE_DIR`). Optional field, default is "var/meta_data". Should be the same as "[bdbStore].bdbEnvHome" if upgrade from version prior `0.5.0`. |
 
 [zookeeper]
 >The corresponding Tom MQ cluster of the Master stores the information about the ZooKeeper cluster of the Offset. The required unit has a fixed value of "[zookeeper]".
@@ -54,7 +55,23 @@ In addition to the back-end system configuration file, the Master also stores th
 | zkSyncTimeMs          | no       | long   | Zk data synchronization time, in milliseconds, default 5 seconds |
 | zkCommitPeriodMs      | no       | long   | The interval at which the Master cache data is flushed to zk, in milliseconds, default 5 seconds. |
 
+[replication]
+>Replication configuration for metadata storage replication and multi-node hot standby between Masters. The required unit has a fixed value of "[replication]".
+
+| Name                    | Required                          | Type                          | Description                                                  |
+| ----------------------- |  ----------------------------- |  ----------------------------- | ------------------------------------------------------------ |
+| repGroupName            | no       | string | Cluster name, the primary and backup master node values must be the same. Optional field, default is "tubemqMasterGroup". |
+| repNodeName             | yes      | string | The name of the master node in the cluster. The value of each node MUST BE DIFFERENT. Required field. |
+| repNodePort             | no       | int    | Node communication port, optional field, default is 9001. |
+| repHelperHost           | no       | string | Primary node when the master cluster starts, optional field, default is "127.0.0.1:9001". |
+| metaLocalSyncPolicy     | no       | int    | Replication data node local storage mode, the value range of this field is [1, 2, 3]. The default is 1: 1 is data saved to disk, 2 is data only saved to memory, and 3 is only data is written to file system buffer without flush. |
+| metaReplicaSyncPolicy   | no       | int    | Replication data node synchronization save mode, the value range of this field is [1, 2, 3]. The default is 1: 1 is data saved to disk, 2 is data only saved to memory, and 3 is only data is written to file system buffer without flush. |
+| repReplicaAckPolicy     | no       | int    | The response policy of the replication node data synchronization, the value range of this field is [1, 2, 3], the default is 1: 1 is more than 1/2 majority is valid, 2 is valid for all nodes, 3 is not Need node response. |
+| repStatusCheckTimeoutMs | no       | long   | Replication status check interval, optional field, in milliseconds, defaults to 10 seconds. |
+
 [bdbStore]
+>Deprecated, config in "[replication]" instead.
+
 >Master configuration of the BDB cluster to which the master belongs. The master uses BDB for metadata storage and multi-node hot standby. The required unit has a fixed value of "[bdbStore]".
 
 | Name                    | Required                          | Type                          | Description                                                  |

--- a/docs/en-us/quick_start.md
+++ b/docs/en-us/quick_start.md
@@ -74,16 +74,11 @@ zkConnectionTimeoutMs=30000
 zkSyncTimeMs=5000
 zkCommitPeriodMs=5000
 
-[bdbStore]
-bdbRepGroupName=tubemqMasterGroup
-bdbNodeName=tubemqMasterGroupNode1
-bdbNodePort=9001
-bdbEnvHome=/stage/metadata
-bdbHelperHost=9.134.8.170:9001
-bdbLocalSync= 1
-bdbReplicaSync= 3
-bdbReplicaAck= 1
-bdbStatusCheckTimeoutMs=10000
+[replication]
+; name of current node; MUST BE DIFFERENT for every node in the cluster
+repNodeName=tubemqMasterGroupNode1
+; helperHost(and port) for nodes to join master cluster
+repHelperHost=YOUR_SERVER_IP:9001
 ```
 
 ##### resources/velocity.properties

--- a/docs/en-us/tubemq_user_guide.md
+++ b/docs/en-us/tubemq_user_guide.md
@@ -75,16 +75,11 @@ zkConnectionTimeoutMs=30000
 zkSyncTimeMs=5000
 zkCommitPeriodMs=5000
 
-[bdbStore]
-bdbRepGroupName=tubemqMasterGroup
-bdbNodeName=tubemqMasterGroupNode1
-bdbNodePort=9001
-bdbEnvHome=/stage/metadata
-bdbHelperHost=9.134.8.170:9001
-bdbLocalSync= 1
-bdbReplicaSync= 3
-bdbReplicaAck= 1
-bdbStatusCheckTimeoutMs=10000
+[replication]
+; name of current node; MUST BE DIFFERENT for every node in the cluster
+repNodeName=tubemqMasterGroupNode1
+; helperHost(and port) for nodes to join master cluster
+repHelperHost=YOUR_SERVER_IP:9001
 ```
 
 ##### resources/velocity.properties

--- a/docs/zh-cn/configure_introduction.md
+++ b/docs/zh-cn/configure_introduction.md
@@ -43,6 +43,7 @@ Master除了后端系统配置文件外，还在resources里存放了Web前端�
 | startConsumeAuthenticate | 否 | boolean | 是否启用消费端用户认证，缺省为false |
 | startConsumeAuthorize | 否 | boolean | 是否启用消费端消费授权认证，缺省为false |
 | maxGroupBrokerConsumeRate | 否 | int | 集群Broker数与消费组里成员数的最大比值，可选项，缺省为50，50台Broker集群里允许1个消费组最少启动1个客户端消费 |
+| metaDataPath | 否 | String | Metadata存储路径，可以是绝对路径、或者相对TubeMQ安装目录（&quot;$BASE_DIR&quot;）的相对路径。缺省为&quot;var/meta_data&quot; |
 |
  |
 | [zookeeper] | Master对应的TubeMQ集群存储Offset的ZooKeeper集群相关信息，必填单元，值固定为&quot;[zookeeper]&quot; |
@@ -54,7 +55,18 @@ Master除了后端系统配置文件外，还在resources里存放了Web前端�
 | zkCommitPeriodMs | 否 | long | Master缓存数据刷新到zk上的时间间隔，单位毫秒，默认5秒 |
 |
  |
-| [bdbStore] | Master所属BDB集群的相关配置，Master采用BDB进行元数据存储以及多节点热备，必填单元，值固定为&quot;[bdbStore]&quot; |
+| [replication] | 集群数据复制的相关配置，用于实现元数据多节点热备，必填单元，值固定为&quot;[replication]&quot; |
+| [replication] | repGroupName | 否 | String | 集群名，所属主备Master节点值必须相同，可选字段，缺省为&quot;tubemqMasterGroup&quot; |
+| repNodeName | 是 | String | 所属Master在集群中的节点名，该值各个节点必须不重复，必填字段 |
+| repNodePort | 否 | int | 节点复制通讯端口，可选字段，缺省为9001 |
+| repHelperHost | 否 | String | 集群启动时的主节点，可选字段，缺省为&quot;127.0.0.1:9001&quot; |
+| metaLocalSyncPolicy | 否 | int | 数据节点本地保存方式，该字段取值范围[1，2，3]，缺省为1：其中1为数据保存到磁盘，2为数据只保存到内存，3为只将数据写文件系统buffer，但不刷盘 |
+| metaReplicaSyncPolicy | 否 | int | 数据节点同步保存方式，该字段取值范围[1，2，3]，缺省为1：其中1为数据保存到磁盘，2为数据只保存到内存，3为只将数据写文件系统buffer，但不刷盘 |
+| repReplicaAckPolicy | 否 | int | 节点数据同步时的应答策略，该字段取值范围为[1，2，3]，缺省为1：其中1为超过1/2多数为有效，2为所有节点应答才有效；3为不需要节点应答 |
+| repStatusCheckTimeoutMs | 否 | long | 节点状态检查间隔，可选字段，单位毫秒，缺省为10秒 |
+|
+ |
+| [bdbStore] | 已弃用，请在&quot;[replication]&quot;单元进行相关配置。Master所属BDB集群的相关配置，Master采用BDB进行元数据存储以及多节点热备，必填单元，值固定为&quot;[bdbStore]&quot; |
 | [bdbStore] | bdbRepGroupName | 是 | String | BDB集群名，所属主备Master节点值必须相同，必填字段 |
 | bdbNodeName | 是 | String | 所属Master在BDB集群中的节点名，该值各个BDB节点必须不重复，必填字段 |
 | bdbNodePort | 否 | int | BDB节点通讯端口，可选字段，缺省为9001 |

--- a/docs/zh-cn/quick_start.md
+++ b/docs/zh-cn/quick_start.md
@@ -69,16 +69,11 @@ zkConnectionTimeoutMs=30000
 zkSyncTimeMs=5000
 zkCommitPeriodMs=5000
 
-[bdbStore]
-bdbRepGroupName=tubemqMasterGroup
-bdbNodeName=tubemqMasterGroupNode1
-bdbNodePort=9001
-bdbEnvHome=/stage/metadata
-bdbHelperHost=9.134.8.170:9001
-bdbLocalSync= 1
-bdbReplicaSync= 3
-bdbReplicaAck= 1
-bdbStatusCheckTimeoutMs=10000
+[replication]
+; name of current node; MUST BE DIFFERENT for every node in the cluster
+repNodeName=tubemqMasterGroupNode1
+; helperHost(and port) for nodes to join master cluster
+repHelperHost=YOUR_SERVER_IP:9001
 ```
 
 ##### resources/velocity.properties

--- a/docs/zh-cn/tubemq_user_guide.md
+++ b/docs/zh-cn/tubemq_user_guide.md
@@ -75,16 +75,11 @@ zkConnectionTimeoutMs=30000
 zkSyncTimeMs=5000
 zkCommitPeriodMs=5000
 
-[bdbStore]
-bdbRepGroupName=tubemqMasterGroup
-bdbNodeName=tubemqMasterGroupNode1
-bdbNodePort=9001
-bdbEnvHome=/stage/metadata
-bdbHelperHost=9.134.8.170:9001
-bdbLocalSync= 1
-bdbReplicaSync= 3
-bdbReplicaAck= 1
-bdbStatusCheckTimeoutMs=10000
+[replication]
+; name of current node; MUST BE DIFFERENT for every node in the cluster
+repNodeName=tubemqMasterGroupNode1
+; helperHost(and port) for nodes to join master cluster
+repHelperHost=YOUR_SERVER_IP:9001
 ```
 
 ##### resources/velocity.properties


### PR DESCRIPTION
Move [bdbStore] configs in master.ini to [replication] & [master], as bdb is an implementation detail, better not to bother users.
```
bdbRepGroupName         --> [replication].repGroupName
bdbNodeName             --> [replication].repNodeName
bdbNodePort             --> [replication].repNodePort
bdbHelperHost           --> [replication].repHelperHost
bdbEnvHome              --> [master].metaDataPath
bdbLocalSync            --> [replication].metaLocalSyncPolicy
bdbReplicaSync          --> [replication].metaReplicaSyncPolicy
bdbReplicaAck           --> [replication].repReplicaAckPolicy
bdbStatusCheckTimeoutMs --> [replication].repStatusCheckTimeoutMs
```

This PR update related docs:
```
docs/(zh-cn/en-us)/configure_introduction.md
docs/(zh-cn/en-us)/quick_start.md
docs/(zh-cn/en-us)/tubemq_user_guide.md
```
Issue: https://issues.apache.org/jira/browse/TUBEMQ-166