### PR TITLE
[TUBEMQ-209] fix home page quick start link error

### DIFF
--- a/site_config/home.jsx
+++ b/site_config/home.jsx
@@ -7,7 +7,7 @@ export default {
       buttons: [
         {
           text: '立即开始',
-          link: '/zh-cn/docs/tubemq_user_guide.html',
+          link: '/zh-cn/docs/quick_start.html',
           type: 'primary',
         },
         {
@@ -65,7 +65,7 @@ export default {
       buttons: [
         {
           text: 'Quick Start',
-          link: '/en-us/docs/tubemq_user_guide.html',
+          link: '/en-us/docs/quick_start.html',
           type: 'primary',
         },
         {


### PR DESCRIPTION
change page quick start link from `/docs/tubeme_user_guide.html` to `/docs/quick_start.html`