### PR TITLE
[TUBEMQ-303]docker script should expose 8123 port

### DIFF
--- a/docs/en-us/quick_start.md
+++ b/docs/en-us/quick_start.md
@@ -52,7 +52,7 @@ This command will generate the Java source files from the `protoc` files, the ge
 ### Deploy TubeMQ Standalone
 Standalone mode starts zookeeper/master/broker services in one docker container：
 ```
-docker run -p 8080:8080 -p 8000:8000 --name tubemq -d apachetubemq/tubemq-all:latest
+docker run -p 8080:8080 -p 8000:8000 -p 8123:8123 --name tubemq -d apachetubemq/tubemq-all:latest
 ```
 Afater container is running, you can access ` http://127.0.0.1:8080`, and reference to next `Quick Start` chapter for experience.
 

--- a/docs/zh-cn/quick_start.md
+++ b/docs/zh-cn/quick_start.md
@@ -46,7 +46,7 @@ mvn compile
 ### 部署TubeMQ Standalone
 Standalone模式可以在一个容器中启动zookeeper/master/broker服务：
 ```
-docker run -p 8080:8080 -p 8000:8000 --name tubemq -d apachetubemq/tubemq-all:latest
+docker run -p 8080:8080 -p 8000:8000 -p 8123:8123 --name tubemq -d apachetubemq/tubemq-all:latest
 ```
 容器拉起后，可在浏览器访问` http://127.0.0.1:8080`，然后参考下面`快速使用`部分开始使用。
 


### PR DESCRIPTION
The PRIVATE_PORT `8123` should expose for broker's communication. 