### PR TITLE
[TUBEMQ-335][Website] Missing translations in quick_start.md (en-us)

### DIFF
--- a/docs/en-us/quick_start.md
+++ b/docs/en-us/quick_start.md
@@ -23,7 +23,7 @@ mvn test
 - Build Individual Module：
 ```bash
 mvn clean install
-cd module-name (比如: tubemq-client)
+cd module-name (e.g. tubemq-client)
 mvn test
 ```
 After the build, please go to `tubemq-server/target`. You can find the


### PR DESCRIPTION
Replace "比如" with "e.g."

Thanks! :)